### PR TITLE
make buttonLeft and buttonRight options optional

### DIFF
--- a/jquery.cloud9carousel.js
+++ b/jquery.cloud9carousel.js
@@ -280,15 +280,19 @@
     }
 
     this.bindControls = function() {
-      options.buttonLeft.bind( 'click', function() {
-        self.go( -1 );
-        return false;
-      } );
+      if( options.buttonLeft ) {
+        options.buttonLeft.bind( 'click', function() {
+          self.go( -1 );
+          return false;
+        } );
+      }
 
-      options.buttonRight.bind( 'click', function() {
-        self.go( 1 );
-        return false;
-      } );
+      if( options.buttonRight ) {
+        options.buttonRight.bind( 'click', function() {
+          self.go( 1 );
+          return false;
+        } );
+      }
 
       if( options.mouseWheel ) {
         $container.bind( 'mousewheel.cloud9', function( event, delta ) {


### PR DESCRIPTION
Any reason we can't make the left and right buttons optional? I want to be able to just call go() manually