### PR TITLE
"main" field in package.json so Browserify works. Tested.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   "bugs": "https://github.com/specious/cloud9carousel/issues",
   "dependencies": {
     "jquery": ">=1.3"
-  }
+  },
+  "main": "jquery.cloud9carousel.js"
 }


### PR DESCRIPTION
If you want to use Browserify with this, it will need to know which JavaScript file to load. Firstly Browserify will check the "main" field (like node.js) else the convention is index.js. Anyway, this PR fixes loading this module via Browserify and probably webpack as well (although I haven't tested that). This is the error I received and which is fixed:

    Running "browserify:watch" (browserify) task
    >> Error: Cannot find module 'cloud9carousel' from '/Users/james/test'